### PR TITLE
Reviewed/tweaked auto_next command line stuff

### DIFF
--- a/vgmrecorder.tcl
+++ b/vgmrecorder.tcl
@@ -177,25 +177,13 @@ proc vgm_rec {args} {
 
 	set auto_next_index [lsearch -exact $args "auto_next"]
 	if {$auto_next_index >= 0} {
-		if {$auto_next_index < [llength $args] - 1} {
-			set auto_next_parameter [lindex $args end]
-			if { $auto_next_parameter == "false"} {
-				if {$auto_next == true} {
-					set auto_next false
-					return "Disabled auto_next feature."
-				} else {
-					error "Auto_next is not active, can't disable it."
-				}
-			} else {
-				error "Wrong parameter"
-			}
-		}
-
-		if { $active } {
+		set param [lindex $args $auto_next_index+1] ;# empty if past end
+		set paramBool [expr {($param eq "") ? true : bool($param)}]
+		if {$active && $paramBool} {
 			error "Auto_next can't be actived during recording, abort/stop the current recording and try again."
 		}
-		set auto_next true
-		return "Enabled auto next feature."
+		set auto_next $paramBool
+		return "[expr {$auto_next ? "Enabled" : "Disabled"}] auto_next feature."
 	}
 
 	if {[lsearch -exact $args "abort"] >= 0} {


### PR DESCRIPTION
Hi,

I think the current script was fine. But since you explicitly asked for a review ...
I've described my changes in the commit message (also pasted below).

As before: I did VERY LITTLE tests on my changes. And feel free to disagree with the changes in functionality.

Wouter



 Commit message:

It's strange to allow "auto_next false" but not "auto_next true". Therefor I
generalized it to 'auto_next [<bool>]'. Any Tcl boolean syntax is allowed (yes,
no, true, false, 0, 1, ..), not specifying the (optional) parameter is the same
as 'true'. I agree that in practice, in interactive mode, the user will never
type "auto_next true". But it could be useful when called from another script.
I did not yet adapt the help text for this stuff, but maybe that's also not
needed?

Personally I don't like errors on stuff like:
  > vgm_rev auto_next false
  ERROR: Auto_next is not active, can't disable it.
Maybe I'm using this in the context of a script and I want to make sure
auto_next is disabled, but I don't know what the current status is. In other
words enabling/disabling when the thing is already enabled/disabled should do
nothing instead of generating an error.